### PR TITLE
Listen on postcode-change event

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,34 @@ POSTCODESERVICE_CLIENT_ID=
 POSTCODESERVICE_SECURE_CODE=
 ```
 
+## Customisation
+
+In case you have your own postcode fields you want checked and updated you can emit the `postcode-change` event passing a reactive object with the following keys:
+    - country_id/country_code
+    - postcode
+    - street[0]
+    - street[1]
+    - city
+
+then you can use it like:
+```html
+<input 
+    v-on:change="window.app.$emit('postcode-change', addressVariables)" 
+    name="postcode" 
+    label="Postcode" 
+    v-model="addressVariables.postcode" 
+    required
+/>
+<input 
+    v-on:change="window.app.$emit('postcode-change', addressVariables)" 
+    name="street[1]" 
+    type="number" 
+    label="Housenumber" 
+    v-model="addressVariables.street[1]" 
+    placeholder=""
+/>
+```
+
 ## Note
 
 Currently only Dutch address completion is implemented!

--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -1,37 +1,55 @@
+import { set, useDebounceFn, useMemoize } from "@vueuse/core";
+
 document.addEventListener('turbo:load', function () {
+    window.app.$on('postcode-change', useDebounceFn(updateAddressFromPostcodeservice, 100));
+
     ['shipping_address', 'billing_address'].forEach((type) => {
         window.app.$watch('checkout.'+type+'.postcode', function () {
-            getAddressFromPostcodeservice(type)
+            window.app.$emit('postcode-change', window.app.checkout[type])
         })
 
         window.app.$watch('checkout.'+type+'.street.1', function () {
-            getAddressFromPostcodeservice(type)
+            window.app.$emit('postcode-change', window.app.checkout[type])
+        })
+
+        window.app.$watch('checkout.'+type+'.country_id', function () {
+            window.app.$emit('postcode-change', window.app.checkout[type])
         })
     })
 })
 
-async function getAddressFromPostcodeservice(type) {
-    if (window.app.checkout[type].country_id != 'NL') {
+const getAddressFromPostcodeservice = useMemoize(
+    async function (postcode, housenumber) {
+        return window.axios.post(window.url('/api/postcodeservice'), {
+            postcode: postcode,
+            housenumber: housenumber,
+        }, {
+            headers: {
+                accept: 'application/json',
+            }
+        })
+    }
+)
+
+async function updateAddressFromPostcodeservice(address) {
+    if ((address?.country_id || address?.country_code) != 'NL') {
         return
     }
 
-    let response = await window.axios.post(window.url('/api/postcodeservice'), {
-        postcode: window.app.checkout[type].postcode,
-        housenumber: window.app.checkout[type].street[1],
-    }, {
-        headers: {
-            accept: 'application/json',
-        }
-    })
+    if(!address.postcode || !(address?.housenumber || address.street[1])) {
+        return
+    }
+
+    let response = await getAddressFromPostcodeservice(address.postcode, address?.housenumber || address.street[1])
 
     if (!response.data?.city || !response.data?.street) {
         if (response.data?.error == "Postcode not found") {
-            window.app.checkout[type].city = ''
-            window.app.checkout[type].street[0] = ''
+            set(address, 'city', '')
+            set(address.street, 0, '')
         }
         return
     }
 
-    window.app.checkout[type].city = response.data.city
-    window.app.checkout[type].street[0] = response.data.street
+    set(address, 'city', response.data.city)
+    set(address.street, 0, response.data.street)
 }

--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -2,20 +2,6 @@ import { set, useDebounceFn, useMemoize } from "@vueuse/core";
 
 document.addEventListener('turbo:load', function () {
     window.app.$on('postcode-change', useDebounceFn(updateAddressFromPostcodeservice, 100));
-
-    ['shipping_address', 'billing_address'].forEach((type) => {
-        window.app.$watch('checkout.'+type+'.postcode', function () {
-            window.app.$emit('postcode-change', window.app.checkout[type])
-        })
-
-        window.app.$watch('checkout.'+type+'.street.1', function () {
-            window.app.$emit('postcode-change', window.app.checkout[type])
-        })
-
-        window.app.$watch('checkout.'+type+'.country_id', function () {
-            window.app.$emit('postcode-change', window.app.checkout[type])
-        })
-    })
 })
 
 const getAddressFromPostcodeservice = useMemoize(


### PR DESCRIPTION
This will not change any functionality by default as we still watch the checkout fields.

However in places we cannot watch we can emit the postcode-change event with the address data.
This will perform the postcode check if relevant and update the City and Street.

Next step is to fire these events in
https://github.com/rapidez/account/blob/06c7eff515295a072369da7e0501f791812a70c5/resources/views/account/partials/address-form.blade.php
https://github.com/rapidez/checkout-theme/blob/1b23b35f230f1bab515c7cbd25bb935602a8616e/resources/views/components/address-form.blade.php#L83
https://github.com/rapidez/account/blob/06c7eff515295a072369da7e0501f791812a70c5/resources/views/account/partials/address-form.blade.php

with an event like:
```
v-on:change="window.app.$emit('postcode-change', addressVariables)"
```