### PR TITLE
Add regex validation for postcode

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -6,7 +6,7 @@ Route::middleware('api')->match(['get', 'post'], '/api/postcodeservice', functio
     $request->merge([
         'postcode' => strtoupper(str_replace(' ', '', $request->postcode)),
     ])->validate([
-        'postcode' => 'required|string|size:6',
+        'postcode' => 'required|string|regex:/\d\d\d\d[A-z][A-z]/',
         'housenumber' => 'required',
     ]);
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,7 +6,7 @@ Route::middleware('api')->match(['get', 'post'], '/api/postcodeservice', functio
     $request->merge([
         'postcode' => strtoupper(str_replace(' ', '', $request->postcode)),
     ])->validate([
-        'postcode' => 'required|string|max:6',
+        'postcode' => 'required|string|size:6',
         'housenumber' => 'required',
     ]);
 


### PR DESCRIPTION
ref: BORDEX-1354

We didn't actually validate what went to the postcode api, which caused an error from the API unnecessarily when people put in an invalid postal code.